### PR TITLE
Change main to reference index.js to fix NPM installing

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "bugs": "https://github.com/joaonuno/tree-model-js/issues",
   "license": "MIT",
   "author": "João Nuno Silva <jnss81@gmail.com> (http://jnuno.com)",
-  "main": "TreeModel.js",
+  "main": "index.js",
   "scripts": {
     "test": "mocha",
     "lint": "jshint index.js test/test.js && jscs index.js test/test.js",


### PR DESCRIPTION
When I NPM installed this package, I was getting an error when trying to require or import it.
Turns out that `main` was pointing to a non-existant file.