### PR TITLE
Shadow TreeModel class name with namespace so that all are exported.

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -9,31 +9,31 @@ declare class TreeModel {
 
     private config: TreeModel.Config;
 
-    parse(model: TreeModel.Model): TreeModel.Node;
+    parse<T>(model: TreeModel.Model<T>): TreeModel.Node<T>;
 }
 
 declare namespace TreeModel {
-    class Node {
-        constructor(config: any, model: Model);
+    class Node<T> {
+        constructor(config: any, model: Model<T>);
 
         isRoot(): boolean;
         hasChildren(): boolean;
-        addChild(child: Node): Node;
-        addChildAtIndex(child: Node, index: number): Node;
-        setIndex(index: number): Node;
-        getPath(): Node[];
+        addChild(child: Node<T>): Node<T>;
+        addChildAtIndex(child: Node<T>, index: number): Node<T>;
+        setIndex(index: number): Node<T>;
+        getPath(): Array<Node<T>>;
         getIndex(): number;
 
-        walk(options: Options, fn: NodeVisitorFunction, ctx?: object): void;
-        walk(fn: NodeVisitorFunction, ctx?: object): void;
+        walk(options: Options, fn: NodeVisitorFunction<T>, ctx?: object): void;
+        walk(fn: NodeVisitorFunction<T>, ctx?: object): void;
 
-        all(options: Options, fn: NodeVisitorFunction, ctx?: object): Node[];
-        all(fn: NodeVisitorFunction, ctx?: object): Node[];
+        all(options: Options, fn: NodeVisitorFunction<T>, ctx?: object): Array<Node<T>>;
+        all(fn: NodeVisitorFunction<T>, ctx?: object): Array<Node<T>>;
 
-        first(options: Options, fn: NodeVisitorFunction, ctx?: object): Node | undefined;
-        first(fn: NodeVisitorFunction, ctx?: object): Node | undefined;
+        first(options: Options, fn: NodeVisitorFunction<T>, ctx?: object): Node<T> | undefined;
+        first(fn: NodeVisitorFunction<T>, ctx?: object): Node<T> | undefined;
 
-        drop(): Node;
+        drop(): Node<T>;
 
         [propName: string]: any;
     }
@@ -54,15 +54,7 @@ declare namespace TreeModel {
     type StrategyName = "pre" | "post" | "breadth";
 
     type ComparatorFunction = (left: any, right: any) => boolean;
-    type NodeVisitorFunction = (visitingNode: Node) => boolean;
+    type NodeVisitorFunction<T> = (visitingNode: Node<T>) => boolean;
 
-    interface Model {
-        /**
-         * Children array property name is set from `config.childrenPropertyName`(default: "children")
-         *
-         * config is passed in `TreeModel` constructor
-         */
-        children?: Model[];
-        [propName: string]: any;
-    }
+    type Model<T> = T & { children?: Array<Model<T>> };
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -5,14 +5,14 @@
 export = TreeModel;
 
 declare class TreeModel {
-    constructor(config?: TreeModelMisc.Config);
+    constructor(config?: TreeModel.Config);
 
-    private config: TreeModelMisc.Config;
+    private config: TreeModel.Config;
 
-    parse(model: TreeModelMisc.Model): TreeModelMisc.Node;
+    parse(model: TreeModel.Model): TreeModel.Node;
 }
 
-declare namespace TreeModelMisc {
+declare namespace TreeModel {
     class Node {
         constructor(config: any, model: Model);
 

--- a/types/tree-model-tests.ts
+++ b/types/tree-model-tests.ts
@@ -1,8 +1,12 @@
 import TreeModel = require("tree-model");
 
+interface TestModel {
+    name: string;
+}
+
 const tree = new TreeModel({});
 
-const root = tree.parse({ name: 'a', children: [{ name: 'b' }, { name: 'c' }] });
+const root = tree.parse<TestModel>({ name: 'a', children: [{ name: 'b' }, { name: 'c' }] });
 
 // $ExpectType boolean
 root.isRoot();
@@ -21,13 +25,13 @@ root.hasChildren();
         type Node = typeof nodeB;
 
         root.addChild({}); // $ExpectError
-        root.addChild(nodeC); // $ExpectType Node
+        root.addChild(nodeC); // $ExpectType Node<TestModel>
 
         root.addChildAtIndex(nodeC); // $ExpectError
-        root.addChildAtIndex(nodeC, 0); // $ExpectType Node
+        root.addChildAtIndex(nodeC, 0); // $ExpectType Node<TestModel>
 
         nodeB.setIndex("first"); // $ExpectError
-        nodeB.setIndex(0); // $ExpectType Node
+        nodeB.setIndex(0); // $ExpectType Node<TestModel>
         const arrPath: Node[] = nodeB.getPath();
         const nodeIndex: number = nodeB.getIndex();
 
@@ -75,6 +79,6 @@ root.hasChildren();
         }
 
         nodeC.drop(nodeC); // $ExpectError
-        nodeC.drop(); // $ExpectType Node
+        nodeC.drop(); // $ExpectType Node<TestModel>
     }
 }


### PR DESCRIPTION
Currently there is no way of importing TreeModelMisc.Node (to my knowledge anyway, please correct me if there is a way!), so it is impossible to type a function like this:

```
import TreeModel = require("tree-model")

...

function asTree(attributeOptions: AttributeOption[]): TreeModelConfig.Node {
  const treeLikeArray = arrayToTree(attributeOptions.map(a => ({...a})), {parentProperty: "parent"})
  const treeModel = new TreeModel()
  return treeModel.parse(treeLikeArray)
}
```

With this change, it is now possible to import the Node type as below:

```
import TreeModel = require("tree-model")

...

function asTree(attributeOptions: AttributeOption[]): TreeModel.Node {
  const treeLikeArray = arrayToTree(attributeOptions.map(a => ({...a})), {parentProperty: "parent"})
  const treeModel = new TreeModel()
  return treeModel.parse(treeLikeArray)
}
```