### PR TITLE
Chore/reduce dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,6 @@
       "name": "tree-model",
       "version": "1.0.7",
       "license": "MIT",
-      "dependencies": {
-        "find-insert-index": "0.0.1"
-      },
       "devDependencies": {
         "@babel/core": "^7.15.5",
         "@babel/eslint-parser": "^7.15.7",
@@ -1351,11 +1348,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/find-insert-index": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/find-insert-index/-/find-insert-index-0.0.1.tgz",
-      "integrity": "sha1-Fs00ZkwqwjOQWrKzl0W87HITYt4="
     },
     "node_modules/find-up": {
       "version": "5.0.0",
@@ -3929,11 +3921,6 @@
       "requires": {
         "to-regex-range": "^5.0.1"
       }
-    },
-    "find-insert-index": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/find-insert-index/-/find-insert-index-0.0.1.tgz",
-      "integrity": "sha1-Fs00ZkwqwjOQWrKzl0W87HITYt4="
     },
     "find-up": {
       "version": "5.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,7 @@
       "version": "1.0.7",
       "license": "MIT",
       "dependencies": {
-        "find-insert-index": "0.0.1",
-        "mergesort": "0.0.1"
+        "find-insert-index": "0.0.1"
       },
       "devDependencies": {
         "@babel/core": "^7.15.5",
@@ -1845,11 +1844,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/mergesort": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/mergesort/-/mergesort-0.0.1.tgz",
-      "integrity": "sha1-Nk7MMbKX3H9E5RHTZRdvHDnQj8I="
     },
     "node_modules/minimatch": {
       "version": "3.0.4",
@@ -4291,11 +4285,6 @@
       "requires": {
         "yallist": "^4.0.0"
       }
-    },
-    "mergesort": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/mergesort/-/mergesort-0.0.1.tgz",
-      "integrity": "sha1-Nk7MMbKX3H9E5RHTZRdvHDnQj8I="
     },
     "minimatch": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -32,10 +32,7 @@
     "prettier": "^2.4.1",
     "sinon": "^5"
   },
-  "dependencies": {
-    "find-insert-index": "0.0.1"
-  },
-  "types": "types",
+"types": "types",
   "prettier": {
     "singleQuote": true,
     "printWidth": 100

--- a/package.json
+++ b/package.json
@@ -33,8 +33,7 @@
     "sinon": "^5"
   },
   "dependencies": {
-    "find-insert-index": "0.0.1",
-    "mergesort": "0.0.1"
+    "find-insert-index": "0.0.1"
   },
   "types": "types",
   "prettier": {

--- a/src/TreeModel.mjs
+++ b/src/TreeModel.mjs
@@ -1,4 +1,3 @@
-import mergeSort from 'mergesort';
 import { Node } from './Node.mjs';
 
 function addChildToNode(node, child) {
@@ -27,10 +26,7 @@ export class TreeModel {
     node = new Node(this.config, model);
     if (model[this.config.childrenPropertyName] instanceof Array) {
       if (this.config.modelComparatorFn) {
-        model[this.config.childrenPropertyName] = mergeSort(
-          this.config.modelComparatorFn,
-          model[this.config.childrenPropertyName]
-        );
+        model[this.config.childrenPropertyName].sort(this.config.modelComparatorFn);
       }
       for (
         i = 0, childCount = model[this.config.childrenPropertyName].length;

--- a/src/addChild.mjs
+++ b/src/addChild.mjs
@@ -1,4 +1,4 @@
-import findInsertIndex from 'find-insert-index';
+import { findInsertIndex } from './findInsertIndex.mjs';
 import { hasComparatorFunction } from './hasCompareFunction.mjs';
 import { Node } from './Node.mjs';
 

--- a/src/findInsertIndex.mjs
+++ b/src/findInsertIndex.mjs
@@ -1,0 +1,16 @@
+/**
+ * Find the index to insert an element in array keeping the sort order.
+ *
+ * @param {function} comparatorFn The comparator function which sorted the array.
+ * @param {array} arr The sorted array.
+ * @param {object} el The element to insert.
+ */
+export function findInsertIndex(comparatorFn, arr, el) {
+  var i, len;
+  for (i = 0, len = arr.length; i < len; i++) {
+    if (comparatorFn(arr[i], el) > 0) {
+      break;
+    }
+  }
+  return i;
+}

--- a/test/findInsertIndex.test.mjs
+++ b/test/findInsertIndex.test.mjs
@@ -1,0 +1,42 @@
+/* global describe, it */
+
+import chai from 'chai';
+import { findInsertIndex } from '../src/findInsertIndex.mjs';
+
+const { assert } = chai;
+
+chai.config.includeStack = true;
+
+describe('findInsertIndex', function () {
+  'use strict';
+
+  it('should get the index to insert the element in the array according to the comparator', function () {
+    var targetArray, comparatorFn;
+
+    comparatorFn = function (a, b) {
+      return a.id - b.id;
+    };
+
+    targetArray = [
+      { id: 0 },
+      { id: 1 },
+      { id: 2 },
+      { id: 3 },
+      { id: 4 },
+      { id: 5 },
+      { id: 6 },
+      { id: 8 },
+      { id: 9 },
+      { id: 10 },
+      { id: 11 },
+      { id: 12 },
+      { id: 13 },
+      { id: 14 },
+      { id: 15 },
+    ];
+
+    assert.equal(findInsertIndex(comparatorFn, [], { id: 7 }), 0);
+    assert.equal(findInsertIndex(comparatorFn, [{ id: 7 }], { id: 7 }), 1);
+    assert.equal(findInsertIndex(comparatorFn, targetArray, { id: 7 }), 7);
+  });
+});


### PR DESCRIPTION
## What I did:

1. use built-in sort (which is stable in all evergreen browser & node)
2. inline `findInsertIndex`
   - there is an array findIndex but that has a slightly different result => mapping that would probably the same amount of code
   - also copied tests
   - why inline? with that everything is esm and works as is without any build in the browser 💪  
   - also 0 dependencies 🎉
  
For easier review you can look at each commit individually  