### PR TITLE
Update index.d.ts

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -17,7 +17,7 @@ declare namespace TreeModel {
         constructor(config: any, model: T);
         model: T;
         children: Node<T>[];
-        parent: Node<T>;
+        parent: Node<T> | undefined;
         isRoot(): boolean;
         hasChildren(): boolean;
         addChild(child: Node<T>): Node<T>;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -4,7 +4,7 @@
 
 export = TreeModel;
 
-declare class TreeModel<T, Config extends TreeModel.Config = TreeModel.Config> {
+declare class TreeModel<Config extends TreeModel.Config = TreeModel.Config> {
     constructor(config?: Config);
 
     private config: Config;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -14,8 +14,8 @@ declare class TreeModel {
 
 declare namespace TreeModel {
     class Node<T> {
-        constructor(config: any, public model: Model<T>) {}
-
+        constructor(config: any, model: Model<T>);
+        model: Model<T>;
         isRoot(): boolean;
         hasChildren(): boolean;
         addChild(child: Node<T>): Node<T>;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -9,13 +9,14 @@ declare class TreeModel<Config extends TreeModel.Config = TreeModel.Config> {
 
     private config: Config;
 
-    parse<T>(model: T & {[Key in Config['childrenPropertyName'] extends string ? Config['childrenPropertyName'] : 'children']: T[] }): TreeModel.Node<T & {[Key in Config['childrenPropertyName'] extends string ? Config['childrenPropertyName'] : 'children']: T[] }>;
+    parse<T extends {[Key in Config['childrenPropertyName'] extends string ? Config['childrenPropertyName'] : 'children']: T[] }>(model: T): TreeModel.Node<T>;
 }
 
 declare namespace TreeModel {
     class Node<T> {
         constructor(config: any, model: T);
         model: T;
+        children: Node<T>[];
         isRoot(): boolean;
         hasChildren(): boolean;
         addChild(child: Node<T>): Node<T>;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -17,6 +17,7 @@ declare namespace TreeModel {
         constructor(config: any, model: T);
         model: T;
         children: Node<T>[];
+        parent: Node<T>;
         isRoot(): boolean;
         hasChildren(): boolean;
         addChild(child: Node<T>): Node<T>;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -4,18 +4,18 @@
 
 export = TreeModel;
 
-declare class TreeModel {
-    constructor(config?: TreeModel.Config);
+declare class TreeModel<T, Config extends TreeModel.Config = TreeModel.Config> {
+    constructor(config?: Config);
 
-    private config: TreeModel.Config;
+    private config: Config;
 
-    parse<T>(model: TreeModel.Model<T>): TreeModel.Node<T>;
+    parse<T>(model: T & {[Key in Config['childrenPropertyName'] extends string ? Config['childrenPropertyName'] : 'children']: T[] }): TreeModel.Node<T & {[Key in Config['childrenPropertyName'] extends string ? Config['childrenPropertyName'] : 'children']: T[] }>;
 }
 
 declare namespace TreeModel {
     class Node<T> {
-        constructor(config: any, model: Model<T>);
-        model: Model<T>;
+        constructor(config: any, model: T);
+        model: T;
         isRoot(): boolean;
         hasChildren(): boolean;
         addChild(child: Node<T>): Node<T>;
@@ -44,7 +44,6 @@ declare namespace TreeModel {
          */
         childrenPropertyName?: string;
         modelComparatorFn?: ComparatorFunction;
-        [propName: string]: any;
     }
 
     interface Options {
@@ -55,6 +54,4 @@ declare namespace TreeModel {
 
     type ComparatorFunction = (left: any, right: any) => boolean;
     type NodeVisitorFunction<T> = (visitingNode: Node<T>) => boolean;
-
-    type Model<T> = T & { children?: Array<Model<T>> };
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -14,7 +14,7 @@ declare class TreeModel {
 
 declare namespace TreeModel {
     class Node<T> {
-        constructor(config: any, model: Model<T>);
+        constructor(config: any, public model: Model<T>) {}
 
         isRoot(): boolean;
         hasChildren(): boolean;


### PR DESCRIPTION
This PR fixes a few things.

1. forces the T type to conform to have whatever property is set within the config
2. adds access to `node.children`
3. adds access to `node.model`
4. adds access to `node.parent`
5. allows extension of the config type from the TreeModel "class" so you don't need to add unknown property index